### PR TITLE
fix: syntax highlighting lost when toggling `Editable` on `MudCodeViewer`

### DIFF
--- a/src/CodeBeam.MudBlazor.Extensions.Code/Components/MudCodeViewer.razor.cs
+++ b/src/CodeBeam.MudBlazor.Extensions.Code/Components/MudCodeViewer.razor.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using MudBlazor;
 using MudBlazor.State;
@@ -23,6 +23,7 @@ public partial class MudCodeViewer : MudComponentBase
     private readonly ParameterState<string?> _code;
     private readonly ParameterState<bool> _showLineNumbers;
     private readonly ParameterState<bool> _wrap;
+    private readonly ParameterState<bool> _editable;
     private readonly ParameterState<bool> _header;
     private readonly ParameterState<CodeLanguage> _language;
 
@@ -41,6 +42,9 @@ public partial class MudCodeViewer : MudComponentBase
             .WithChangeHandler(ParameterChanged);
         _wrap = registerScope.RegisterParameter<bool>(nameof(Wrap))
             .WithParameter(() => Wrap)
+            .WithChangeHandler(ParameterChanged);
+        _editable = registerScope.RegisterParameter<bool>(nameof(Editable))
+            .WithParameter(() => Editable)
             .WithChangeHandler(ParameterChanged);
         _header = registerScope.RegisterParameter<bool>(nameof(ShowHeader))
             .WithParameter(() => ShowHeader)
@@ -174,13 +178,13 @@ public partial class MudCodeViewer : MudComponentBase
             await RefreshAsync();
         }
 
-        if (Editable && !_tabEnabled)
+        if (_editable.Value && !_tabEnabled)
         {
             await JS.InvokeVoidAsync("MudCode.enableTabIndent", _textAreaRef);
             _tabEnabled = true;
         }
 
-        if (!Editable)
+        if (!_editable.Value)
         {
             _tabEnabled = false;
         }


### PR DESCRIPTION
When the `Editable` parameter changes, syntax highlighting is lost
until the text is modified.

This happens because no parameter scope is registered for `Editable`,
so `ParameterChanged` is never invoked on change. As a result, the
`MudCode.highlight` JS function isn't called after the DOM updates,
leaving the code unhighlighted.

I ran into this in my project; it's also reported in #628.

The fix registers `Editable` in the parameter scope, the same way as
`Code`, `ShowLineNumbers`, etc. This ensures `ParameterChanged` fires
when `Editable` changes, triggering `MudCode.highlight` to re-highlight
the code after the DOM update.