### PR TITLE
Fix project compilation on Linux and macOS

### DIFF
--- a/src/CodeBeam.MudBlazor.Extensions/CodeBeam.MudBlazor.Extensions.csproj
+++ b/src/CodeBeam.MudBlazor.Extensions/CodeBeam.MudBlazor.Extensions.csproj
@@ -44,9 +44,9 @@
 		<PackageReference Include="MudBlazor" Version="9.0.0" />
 	</ItemGroup>
 
-	<Target Name="MinifyMudExtensionsJs" AfterTargets="Build" Condition="'$(CI)' != 'true'&#xD;&#xA; AND '$(TargetFramework)' == 'net10.0'&#xD;&#xA;               AND Exists('TScripts/MudExtensions.js')">
+	<Target Name="MinifyMudExtensionsJs" AfterTargets="Build" Condition="'$(CI)' != 'true' AND '$(TargetFramework)' == 'net10.0' AND Exists('TScripts/MudExtensions.js')">
 		<Message Importance="high" Text="Minifying MudExtensions.js → MudExtensions.min.js" />
-		<Exec WorkingDirectory="$(SolutionDir)" Command="dotnet run --project utilities\CodeBeam.MudBlazor.Extensions.JsMinifier\CodeBeam.MudBlazor.Extensions.JsMinifier.csproj --configuration $(Configuration)" />
+		<Exec WorkingDirectory="$(SolutionDir)" Command="dotnet run --project utilities/CodeBeam.MudBlazor.Extensions.JsMinifier/CodeBeam.MudBlazor.Extensions.JsMinifier.csproj --configuration $(Configuration)" />
 	</Target>
 
 	<ItemGroup>


### PR DESCRIPTION
Using \ only works on Windows whereas using / works on all .NET platforms

Also simplify the associated MSBuild condition